### PR TITLE
Add version command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Binaries folder
+output
+
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+PROJECT_NAME := ovh-cli
+PKG := github.com/AdFabConnect/ovh-cli
+OUTPUT_DIR := output
+
+GO_VERSION := $(shell go version | awk '{print $$3}' )
+APP_VERSION := $(shell git describe --tag >/dev/null 2>&1; if [ $$? -ne 0 ]; then git rev-parse --short HEAD; else git describe --tag; fi)
+GIT_COMMIT := $(shell git rev-parse HEAD)
+BUILD_DATE := $(shell date '+%Y-%m-%d_%H:%M:%S' )
+
+LDFLAGS = '-X ${PKG}/cmd.Version=${APP_VERSION} -X ${PKG}/cmd.GoVersion=${GO_VERSION} -X ${PKG}/cmd.OsArchi=${GOOS}/${GOARCH} -X ${PKG}/cmd.GitCommit=${GIT_COMMIT} -X ${PKG}/cmd.BuildDate=${BUILD_DATE}'
+OUTPUT = ${OUTPUT_DIR}/${GOOS}-${GOARCH}/${PROJECT_NAME}
+
+.PHONY: all
+all: build
+
+.PHONY: build
+build:
+	$(eval GOOS := $(shell go env GOOS))
+	$(eval GOARCH := $(shell go env GOARCH))
+	@echo "Build and install ${PROJECT_NAME} - ${GOOS} ${GOARCH}"
+	@go build -o ${OUTPUT} ${FLAGS} -ldflags ${LDFLAGS}
+
+
+.PHONY: clean
+clean:
+	rm -rf ${OUTPUT_DIR}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	GitCommit string
+	Version   string
+	GoVersion string
+	OsArchi   string
+	BuildDate string
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("Version:    %s\n", Version)
+		fmt.Printf("Commit:     %s\n", GitCommit)
+		fmt.Printf("Build date: %s\n", BuildDate)
+		fmt.Printf("Go version: %s\n", GoVersion)
+		fmt.Printf("OS/Arch::   %s\n", OsArchi)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}


### PR DESCRIPTION
Implement version command. This command will display base information:
```
Version:    0.0.1
Commit:     39e6da37d905fe87eac3b1efb52979fa4218e68a
Build date: 2019-05-10_19:16:46
Go version: go1.12.5
OS/Arch::   linux/amd64
```
Version is extracted from git tag. If no tag is available on current commit, short commit hash will be used.